### PR TITLE
Add Criterion test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc make
+
+      - name: Build and run tests
+        run: |
+          cd tests
+          make test


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that:

- Runs Criterion tests using the bundled framework
- Executes in the tests directory using make test
- Triggers on pushes and pull requests to main branch
- Uses local Criterion installation (no system dependencies)